### PR TITLE
TLS support for ALPN handlers

### DIFF
--- a/address.go
+++ b/address.go
@@ -28,6 +28,26 @@ import (
 
 type Configuration map[interface{}]interface{}
 
+// Protocols returns supported or requested application protocols (used for ALPN support)
+func (self Configuration) Protocols() []string {
+	if self == nil {
+		return nil
+	}
+
+	p, found := self["protocol"]
+	if found {
+		switch v := p.(type) {
+		case string:
+			return []string{v}
+		case []string:
+			return v
+		default:
+			panic("invalid transport.Configuration[protocols] type")
+		}
+	}
+	return nil
+}
+
 // Address implements the functionality provided by a generic "address".
 type Address interface {
 	Dial(name string, i *identity.TokenId, timeout time.Duration, tcfg Configuration) (Conn, error)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/pion/dtls/v2 v2.2.7
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.8.4
+	golang.org/x/net v0.9.0
 	nhooyr.io/websocket v1.8.7
 )
 
@@ -31,7 +33,11 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/parallaxsecond/parsec-client-go v0.0.0-20220111122524-cb78842db373 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
@@ -330,6 +331,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -452,6 +454,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -901,6 +904,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/tls/address.go
+++ b/tls/address.go
@@ -37,20 +37,15 @@ type address struct {
 }
 
 func (a address) Dial(name string, i *identity.TokenId, timeout time.Duration, cfg transport.Configuration) (transport.Conn, error) {
-	var protocols []string
-	proto, found := cfg["protocol"]
-	if found {
-		protocols = append(protocols, proto.(string))
-	}
-	return Dial(a.bindableAddress(), name, i, timeout, protocols...)
+	return Dial(a.bindableAddress(), name, i, timeout, cfg.Protocols()...)
 }
 
 func (a address) DialWithLocalBinding(name string, localBinding string, i *identity.TokenId, timeout time.Duration, tcfg transport.Configuration) (transport.Conn, error) {
-	return DialWithLocalBinding(a.bindableAddress(), name, localBinding, i, timeout)
+	return DialWithLocalBinding(a.bindableAddress(), name, localBinding, i, timeout, tcfg.Protocols()...)
 }
 
-func (a address) Listen(name string, i *identity.TokenId, acceptF func(transport.Conn), _ transport.Configuration) (io.Closer, error) {
-	return Listen(a.bindableAddress(), name, i, acceptF)
+func (a address) Listen(name string, i *identity.TokenId, acceptF func(transport.Conn), tcfg transport.Configuration) (io.Closer, error) {
+	return Listen(a.bindableAddress(), name, i, acceptF, tcfg.Protocols()...)
 }
 
 func (a address) MustListen(name string, i *identity.TokenId, acceptF func(transport.Conn), tcfg transport.Configuration) io.Closer {

--- a/tls/address.go
+++ b/tls/address.go
@@ -36,8 +36,13 @@ type address struct {
 	port     uint16
 }
 
-func (a address) Dial(name string, i *identity.TokenId, timeout time.Duration, _ transport.Configuration) (transport.Conn, error) {
-	return Dial(a.bindableAddress(), name, i, timeout)
+func (a address) Dial(name string, i *identity.TokenId, timeout time.Duration, cfg transport.Configuration) (transport.Conn, error) {
+	var protocols []string
+	proto, found := cfg["protocol"]
+	if found {
+		protocols = append(protocols, proto.(string))
+	}
+	return Dial(a.bindableAddress(), name, i, timeout, protocols...)
 }
 
 func (a address) DialWithLocalBinding(name string, localBinding string, i *identity.TokenId, timeout time.Duration, tcfg transport.Configuration) (transport.Conn, error) {

--- a/tls/connection.go
+++ b/tls/connection.go
@@ -39,5 +39,10 @@ func (self *Connection) Detail() *transport.ConnectionDetail {
 }
 
 func (self *Connection) PeerCertificates() []*x509.Certificate {
+	_ = self.Handshake()
 	return self.ConnectionState().PeerCertificates
+}
+
+func (self *Connection) Protocol() string {
+	return self.ConnectionState().NegotiatedProtocol
 }

--- a/tls/dialer.go
+++ b/tls/dialer.go
@@ -48,14 +48,20 @@ func Dial(destination, name string, i *identity.TokenId, timeout time.Duration, 
 	}, nil
 }
 
-func DialWithLocalBinding(destination, name, localBinding string, i *identity.TokenId, timeout time.Duration) (transport.Conn, error) {
+func DialWithLocalBinding(destination, name, localBinding string, i *identity.TokenId, timeout time.Duration, protocols ...string) (transport.Conn, error) {
 	dialer, err := transport.NewDialerWithLocalBinding("tcp", timeout, localBinding)
 
 	if err != nil {
 		return nil, err
 	}
 
-	socket, err := tls.DialWithDialer(dialer, "tcp", destination, i.ClientTLSConfig())
+	tlsCfg := i.ClientTLSConfig()
+	if len(protocols) > 0 {
+		tlsCfg = tlsCfg.Clone()
+		tlsCfg.NextProtos = append(tlsCfg.NextProtos, protocols...)
+	}
+
+	socket, err := tls.DialWithDialer(dialer, "tcp", destination, tlsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/tls/dialer.go
+++ b/tls/dialer.go
@@ -26,10 +26,12 @@ import (
 	"time"
 )
 
-func Dial(destination, name string, i *identity.TokenId, timeout time.Duration) (transport.Conn, error) {
+func Dial(destination, name string, i *identity.TokenId, timeout time.Duration, protocols ...string) (transport.Conn, error) {
 	log := pfxlog.Logger()
 
-	socket, err := tls.DialWithDialer(&net.Dialer{Timeout: timeout}, "tcp", destination, i.ClientTLSConfig())
+	tlsCfg := i.ClientTLSConfig().Clone()
+	tlsCfg.NextProtos = protocols
+	socket, err := tls.DialWithDialer(&net.Dialer{Timeout: timeout}, "tcp", destination, tlsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/tls/listener.go
+++ b/tls/listener.go
@@ -20,22 +20,27 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/identity"
 	"github.com/openziti/transport/v2"
+	"github.com/sirupsen/logrus"
 	"io"
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
+var noProtocol = []string{""}
+
 func Listen(bindAddress, name string, i *identity.TokenId, acceptF func(transport.Conn), protocols ...string) (io.Closer, error) {
-	//log := pfxlog.ContextLogger(name + "/" + Type + ":" + bindAddress).Entry
+	log := pfxlog.ContextLogger(name + "/" + Type + ":" + bindAddress).Entry
 
 	config := i.ServerTLSConfig().Clone()
 	if len(protocols) > 0 {
 		config.NextProtos = append(config.NextProtos, protocols...)
 	}
-	result := &acceptor{
+	result := &protocolHandler{
 		name:    name,
 		tls:     config,
 		acceptF: acceptF,
@@ -43,13 +48,72 @@ func Listen(bindAddress, name string, i *identity.TokenId, acceptF func(transpor
 
 	err := registerWithSharedListener(bindAddress, result)
 	if err != nil {
+		log.WithError(err).Error("failed to register with shared listener")
 		return nil, err
 	}
 
 	return result, nil
 }
 
-type acceptor struct {
+type tlsListener struct {
+	connCh  chan *Connection
+	handler *protocolHandler
+	closed  atomic.Bool
+}
+
+func (self *tlsListener) Accept() (net.Conn, error) {
+	conn := <-self.connCh
+	if conn == nil {
+		return nil, net.ErrClosed
+	}
+	return conn.Conn, nil
+}
+
+func (self *tlsListener) Close() error {
+	var err error
+	if self.closed.CompareAndSwap(false, true) {
+		err = self.handler.Close()
+		close(self.connCh)
+	}
+	return err
+}
+
+func (self *tlsListener) Addr() net.Addr {
+	return self.handler.listener.sock.Addr()
+}
+
+func (self *tlsListener) tlsAccept(conn transport.Conn) {
+	c := conn.(*Connection)
+	self.connCh <- c
+}
+
+// ListenTLS returns net.Listener that is attached to shared listener with protocols (ALPN)
+// specified by config.NextProtos
+// It can be used in http.Server or other standard components
+func ListenTLS(bindAddress, name string, config *tls.Config) (net.Listener, error) {
+	log := pfxlog.ContextLogger(name + "/" + Type + ":" + bindAddress).Entry
+
+	l := &tlsListener{}
+
+	handler := &protocolHandler{
+		name:    name,
+		tls:     config,
+		acceptF: l.tlsAccept,
+	}
+
+	err := registerWithSharedListener(bindAddress, handler)
+	if err != nil {
+		log.WithError(err).Error("failed to register with shared listener")
+		return nil, err
+	}
+
+	l.handler = handler
+	l.connCh = make(chan *Connection, 16)
+
+	return l, nil
+}
+
+type protocolHandler struct {
 	name     string
 	listener *sharedListener
 	tls      *tls.Config
@@ -57,7 +121,7 @@ type acceptor struct {
 	closed   atomic.Bool
 }
 
-func (self *acceptor) Close() error {
+func (self *protocolHandler) Close() error {
 	if self.closed.CompareAndSwap(false, true) {
 		self.listener.remove(self)
 		return nil
@@ -65,50 +129,24 @@ func (self *acceptor) Close() error {
 	return nil
 }
 
-//func (self *acceptor) acceptLoop(log *logrus.Entry) {
-//	defer log.Info("exited")
-//
-//	for !self.closed.Load() {
-//		socket, err := self.listener.Accept()
-//		if err != nil {
-//			if self.closed.Load() {
-//				log.WithField("err", err).Info("listener closed, exiting")
-//				return
-//			}
-//			log.WithField("err", err).Error("accept failed. Failure not recoverable. Exiting listen loop")
-//			return
-//		} else {
-//			connection := &Connection{
-//				detail: &transport.ConnectionDetail{
-//					Address: Type + ":" + socket.RemoteAddr().String(),
-//					InBound: true,
-//					Name:    self.name,
-//				},
-//				Conn: socket.(*tls.Conn),
-//			}
-//			self.acceptF(connection)
-//		}
-//	}
-//}
-
 var sharedListeners sync.Map
 
-func init() {
-}
-
-func registerWithSharedListener(bindAddress string, acc *acceptor) error {
+func registerWithSharedListener(bindAddress string, acc *protocolHandler) error {
 	sl := &sharedListener{
 		address: bindAddress,
 	}
-	sl.tlsCfg = &tls.Config{
-		GetConfigForClient: sl.getConfig,
-	}
-
 	el, found := sharedListeners.LoadOrStore(bindAddress, sl)
 	sl = el.(*sharedListener)
 
 	if !found {
-		sl.acceptors = make(map[string]*acceptor)
+		sl.log = pfxlog.ContextLogger(Type + ":" + bindAddress).Entry
+
+		sl.tlsCfg = &tls.Config{
+			GetConfigForClient: sl.getConfig,
+		}
+
+		sl.ctx, sl.done = context.WithCancel(context.Background())
+		sl.handlers = make(map[string]*protocolHandler)
 		sock, err := tls.Listen("tcp", bindAddress, sl.tlsCfg)
 		if err != nil {
 			sharedListeners.Delete(bindAddress)
@@ -123,78 +161,114 @@ func registerWithSharedListener(bindAddress string, acc *acceptor) error {
 		protos = append(protos, "")
 	}
 
+	sl.mtx.Lock()
+	defer sl.mtx.Unlock()
+
 	// check for conflict
 	for _, proto := range protos {
-		if _, exists := sl.acceptors[proto]; exists {
+		if _, exists := sl.handlers[proto]; exists {
 			return fmt.Errorf("handler for protocol[%s] already exists", proto)
 		}
 	}
 
 	acc.listener = sl
 	for _, proto := range protos {
-		sl.acceptors[proto] = acc
+		sl.handlers[proto] = acc
 	}
 
 	return nil
 }
 
 type sharedListener struct {
-	address   string
-	tlsCfg    *tls.Config
-	acceptors map[string]*acceptor // proto -> acceptor
-	ctx       context.Context
-	sock      net.Listener
+	log      logrus.FieldLogger
+	address  string
+	tlsCfg   *tls.Config
+	mtx      sync.RWMutex
+	handlers map[string]*protocolHandler // proto -> protocolHandler
+	ctx      context.Context
+	done     context.CancelFunc
+	sock     net.Listener
+}
+
+func (self *sharedListener) processConn(conn *tls.Conn) {
+	log := self.log
+	// sharedListener.getConfig will select the right handler during handshake based on ClientHelloInfo
+	// no need to do another look up here
+	var handler *protocolHandler
+	hsCtx, cancelF := context.WithTimeout(context.WithValue(self.ctx, "handler", &handler), 5*time.Second)
+	defer cancelF()
+
+	err := conn.HandshakeContext(hsCtx)
+	if err != nil {
+		log.WithError(err).Error("handshake failed")
+		_ = conn.Close()
+		return
+	}
+
+	proto := conn.ConnectionState().NegotiatedProtocol
+	log.WithField("client", conn.RemoteAddr()).Debug("selected protocol = '", proto, "'")
+
+	connection := &Connection{
+		detail: &transport.ConnectionDetail{
+			Address: Type + ":" + conn.RemoteAddr().String(),
+			InBound: true,
+			Name:    handler.name,
+		},
+		Conn: conn,
+	}
+	handler.acceptF(connection)
 }
 
 func (self *sharedListener) runAccept() {
+	log := self.log
+	defer log.Info("exited")
 	for {
 		c, err := self.sock.Accept()
 		if err != nil {
+			if self.ctx.Err() != nil {
+				log.WithError(err).Info("listener closed, exiting")
+				return
+			}
+			log.WithError(err).Error("accept failed, exiting")
 			return
 		}
 
 		conn := c.(*tls.Conn)
-		err = conn.Handshake()
-		if err != nil {
-			_ = conn.Close()
-			continue
-		}
 
-		proto := conn.ConnectionState().NegotiatedProtocol
-
-		acc, found := self.acceptors[proto]
-		if found {
-			connection := &Connection{
-				detail: &transport.ConnectionDetail{
-					Address: Type + ":" + conn.RemoteAddr().String(),
-					InBound: true,
-					Name:    acc.name,
-				},
-				Conn: conn,
-			}
-			acc.acceptF(connection)
-		} else {
-			_ = conn.Close()
-		}
+		go self.processConn(conn)
 	}
 }
 
 func (self *sharedListener) getConfig(info *tls.ClientHelloInfo) (*tls.Config, error) {
+	log := self.log.WithField("client", info.Conn.RemoteAddr())
+
 	protos := info.SupportedProtos
+	log.Debug("client requesting protocols = ", protos)
+
 	if protos == nil {
-		protos = append(protos, "")
+		protos = noProtocol
 	}
 
+	ctx := info.Context()
+	handler := ctx.Value("handler").(**protocolHandler)
+
+	self.mtx.RLock()
+	defer self.mtx.RUnlock()
+
 	for _, proto := range protos {
-		acc, found := self.acceptors[proto]
+		acc, found := self.handlers[proto]
 		if found {
+			log.Debugf("found handler for proto[%s]", proto)
+			*handler = acc
 			cfg := acc.tls
 			if cfg.GetConfigForClient != nil {
 				c, _ := cfg.GetConfigForClient(info)
 				if c != nil {
-					return c, nil
+					cfg = c
 				}
 			}
+			cfg = cfg.Clone()
+			cfg.NextProtos = []string{proto}
 			return cfg, nil
 		}
 	}
@@ -202,16 +276,25 @@ func (self *sharedListener) getConfig(info *tls.ClientHelloInfo) (*tls.Config, e
 	return nil, fmt.Errorf("not handler for requested protocols %+v", protos)
 }
 
-func (self *sharedListener) remove(acc *acceptor) {
-	if len(acc.tls.NextProtos) == 0 {
-		delete(self.acceptors, "")
-	} else {
-		for _, p := range acc.tls.NextProtos {
-			delete(self.acceptors, p)
-		}
+func (self *sharedListener) remove(h *protocolHandler) {
+	self.log.WithField("name", h.name).Debug("removing handler")
+
+	protos := h.tls.NextProtos
+	if protos == nil {
+		protos = noProtocol
 	}
-	if len(self.acceptors) == 0 {
+
+	for _, p := range h.tls.NextProtos {
+		delete(self.handlers, p)
+	}
+
+	self.mtx.Lock()
+	defer self.mtx.Unlock()
+
+	if len(self.handlers) == 0 {
+		self.log.Debug("no handlers left. stopping")
 		sharedListeners.Delete(self.address)
+		self.done()
 		_ = self.sock.Close()
 	}
 }

--- a/tls/listener_test.go
+++ b/tls/listener_test.go
@@ -1,0 +1,317 @@
+package tls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"github.com/openziti/identity"
+	"github.com/openziti/transport/v2"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+type testIdentity struct {
+	serverCert *tls.Certificate
+	clientCert *tls.Certificate
+	capool     *x509.CertPool
+}
+
+var serverId testIdentity
+var clientId testIdentity
+
+const (
+	CA_cert = iota
+	Server_cert
+	Client_cert
+)
+
+func init() {
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(CA_cert),
+		Subject: pkix.Name{
+			CommonName:   "testCA",
+			Organization: []string{"Openziti"},
+			Country:      []string{"US"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute * 20),
+
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+
+		SubjectKeyId: []byte{1, 2, 3, 4},
+		KeyUsage:     x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, caKey.Public(), caKey)
+	caCert, _ := x509.ParseCertificate(caCertBytes)
+
+	serverTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(Server_cert),
+		Subject: pkix.Name{
+			CommonName:   "testServer",
+			Organization: []string{"Openziti"},
+			Country:      []string{"US"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute * 5),
+
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+
+		SubjectKeyId: []byte{1, 2, 3, 4},
+		KeyUsage:     x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+
+		BasicConstraintsValid: true,
+
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1).To4()},
+	}
+
+	serverKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	servCert, err := x509.CreateCertificate(rand.Reader, &serverTemplate, &caTemplate, serverKey.Public(), caKey)
+	if err != nil {
+		panic(err)
+	}
+
+	cltTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(Client_cert),
+		Subject: pkix.Name{
+			CommonName:   "testClient",
+			Organization: []string{"Openziti"},
+			Country:      []string{"US"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute * 5),
+
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+
+		SubjectKeyId:          []byte{1, 2, 3, 4},
+		KeyUsage:              x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	clientKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	clientCert, err := x509.CreateCertificate(rand.Reader, &cltTemplate, &caTemplate, clientKey.Public(), caKey)
+	if err != nil {
+		panic(err)
+	}
+
+	serverId = testIdentity{
+		serverCert: &tls.Certificate{
+			Certificate: [][]byte{servCert},
+			PrivateKey:  serverKey,
+		},
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	clientId = testIdentity{
+		capool: pool,
+		clientCert: &tls.Certificate{
+			Certificate: [][]byte{clientCert},
+			PrivateKey:  clientKey,
+		},
+	}
+}
+
+func (t testIdentity) Cert() *tls.Certificate {
+	return t.clientCert
+}
+
+func (t testIdentity) ServerCert() []*tls.Certificate {
+	return []*tls.Certificate{t.serverCert}
+}
+
+func (t testIdentity) CA() *x509.CertPool {
+	return t.capool
+}
+
+func (t testIdentity) CaPool() *identity.CaPool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t testIdentity) ServerTLSConfig() *tls.Config {
+	return &tls.Config{
+		ClientAuth:   tls.RequireAnyClientCert,
+		Certificates: []tls.Certificate{*t.serverCert},
+	}
+}
+
+func (t testIdentity) ClientTLSConfig() *tls.Config {
+	return &tls.Config{
+		GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return t.clientCert, nil
+		},
+		RootCAs: t.capool,
+	}
+}
+
+func (t testIdentity) Reload() error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t testIdentity) WatchFiles() error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t testIdentity) StopWatchingFiles() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t testIdentity) SetCert(pem string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t testIdentity) SetServerCert(pem string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (t testIdentity) GetConfig() *identity.Config {
+	//TODO implement me
+	panic("implement me")
+}
+
+func makeGreeter(proto string) func(c transport.Conn) {
+	return func(c transport.Conn) {
+		msg := "Hello from " + proto
+		_, _ = c.Write([]byte(msg))
+		_ = c.Close()
+	}
+}
+
+func checkClient(addr string, proto string, expected string, t *testing.T) error {
+	clt := &identity.TokenId{
+		Identity: clientId,
+		Token:    "client",
+		Data:     nil,
+	}
+
+	var c transport.Conn
+	var err error
+	if proto == "" {
+		c, err = Dial(addr, "test-dialer", clt, time.Second)
+
+	} else {
+		c, err = Dial(addr, "test-dialer", clt, time.Second, proto)
+	}
+	if err != nil {
+		return err
+	}
+
+	tlsConn := c.(*Connection)
+	fmt.Println("proto = ", tlsConn.Protocol())
+	buf := make([]byte, 1024)
+	n, err := c.Read(buf)
+	if err != nil {
+		return err
+	} else {
+		recv := string(buf[:n])
+		fmt.Println(recv)
+		if recv != "Hello from "+expected {
+			t.Error("wrong handler")
+		}
+	}
+	return nil
+}
+
+func TestListen(t *testing.T) {
+
+	ident := &identity.TokenId{
+		Identity: serverId,
+		Token:    "test",
+		Data:     nil,
+	}
+
+	testAddress := "localhost:14444"
+
+	if _, ok := sharedListeners.Load(testAddress); ok {
+		t.Error("should be empty")
+	}
+
+	fooListener, err := Listen(testAddress, "fooListener", ident, makeGreeter("foo"), "foo")
+
+	count := 0
+	sharedListeners.Range(func(key, value any) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Error("should have single shared listener")
+	}
+
+	el, ok := sharedListeners.Load(testAddress)
+	if !ok {
+		t.Error("should have shared listener")
+	}
+
+	barListener, err := Listen(testAddress, "fooListener", ident, makeGreeter("bar"), "bar", "")
+
+	el, ok = sharedListeners.Load(testAddress)
+	if !ok {
+		t.Error("should have shared listener")
+	}
+
+	sl := el.(*sharedListener)
+	if len(sl.acceptors) != 3 {
+		t.Error("should have a three handled protocols")
+	}
+
+	if sl.acceptors[""] != sl.acceptors["bar"] {
+		t.Error("should be handled by the same acceptor")
+	}
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err = checkClient(testAddress, "foo", "foo", t); err != nil {
+		t.Error(err)
+	}
+	if err = checkClient(testAddress, "bar", "bar", t); err != nil {
+		t.Error(err)
+	}
+
+	err = checkClient(testAddress, "baz", "baz", t)
+	if err == nil {
+		t.Error("this should've failed")
+	}
+
+	err = checkClient(testAddress, "", "bar", t)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_ = fooListener.Close()
+
+	err = checkClient(testAddress, "foo", "foo", t)
+	if err == nil {
+		t.Error("this should've failed")
+	}
+
+	if len(sl.acceptors) != 2 {
+		t.Errorf("2 protocols should be remaining, found %d acceptors", len(sl.acceptors))
+	}
+
+	_ = barListener.Close()
+
+	if _, ok = sharedListeners.Load(testAddress); ok {
+		t.Error("failed to shutdown shared listener")
+	}
+}

--- a/tls/listener_test.go
+++ b/tls/listener_test.go
@@ -55,7 +55,7 @@ func init() {
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 	}
-	caCertBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, caKey.Public(), caKey)
+	caCertBytes, _ := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, caKey.Public(), caKey)
 	caCert, _ := x509.ParseCertificate(caCertBytes)
 
 	serverTemplate := x509.Certificate{
@@ -176,12 +176,12 @@ func (t testIdentity) StopWatchingFiles() {
 	panic("implement me")
 }
 
-func (t testIdentity) SetCert(pem string) error {
+func (t testIdentity) SetCert(_ string) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (t testIdentity) SetServerCert(pem string) error {
+func (t testIdentity) SetServerCert(_ string) error {
 	//TODO implement me
 	panic("implement me")
 }
@@ -262,13 +262,16 @@ func TestListen(t *testing.T) {
 
 	el, ok := sharedListeners.Load(testAddress)
 	req.True(ok, "should have shared listener")
+	sl := el.(*sharedListener)
+	req.Equal(1, len(sl.handlers))
 
 	barListener, err := Listen(testAddress, "fooListener", ident, makeGreeter("bar"), "bar", "")
+	req.NoError(err)
 
 	el, ok = sharedListeners.Load(testAddress)
 	req.True(ok, "should have shared listener")
 
-	sl := el.(*sharedListener)
+	sl = el.(*sharedListener)
 	req.Equal(3, len(sl.handlers), "should have a three handled protocols")
 
 	req.Same(sl.handlers[""], sl.handlers["bar"], "should be handled by the same protocolHandler")


### PR DESCRIPTION
this change allows to register multiple handlers (differentiated by application protocol) for the same network bind address
