### PR TITLE
feat: add HTTPS proxy support (type: https)

### DIFF
--- a/address.go
+++ b/address.go
@@ -188,14 +188,16 @@ func (self Configuration) getValue(index int, key ...string) (interface{}, error
 type ProxyType string
 
 const (
-	ProxyTypeNone        ProxyType = "none"
-	ProxyTypeHttpConnect ProxyType = "http"
+	ProxyTypeNone         ProxyType = "none"
+	ProxyTypeHttpConnect  ProxyType = "http"
+	ProxyTypeHttpsConnect ProxyType = "https"
 )
 
 type ProxyConfiguration struct {
-	Type    ProxyType
-	Address string
-	Auth    *proxy.Auth
+	Type       ProxyType
+	Address    string
+	Auth       *proxy.Auth
+	SkipVerify bool
 }
 
 func LoadProxyConfiguration(cfg map[interface{}]interface{}) (*ProxyConfiguration, error) {
@@ -220,6 +222,8 @@ func LoadProxyConfiguration(cfg map[interface{}]interface{}) (*ProxyConfiguratio
 	switch proxyType {
 	case string(ProxyTypeHttpConnect):
 		result.Type = ProxyTypeHttpConnect
+	case string(ProxyTypeHttpsConnect):
+		result.Type = ProxyTypeHttpsConnect
 	default:
 		return nil, errors.Errorf("invalid proxy type %s", proxyType)
 	}
@@ -250,6 +254,14 @@ func LoadProxyConfiguration(cfg map[interface{}]interface{}) (*ProxyConfiguratio
 			} else {
 				return nil, errors.Errorf("invalid value for %s proxy password [%v], must be string", string(result.Type), val)
 			}
+		}
+	}
+
+	if val, found = cfg["skipVerify"]; found {
+		if skipVerify, ok := val.(bool); ok {
+			result.SkipVerify = skipVerify
+		} else {
+			return nil, errors.Errorf("invalid value for %s proxy skipVerify [%v], must be bool", string(result.Type), val)
 		}
 	}
 

--- a/address_test.go
+++ b/address_test.go
@@ -47,6 +47,100 @@ func TestParseAddressHostPort(t *testing.T) {
 	}
 }
 
+func TestLoadProxyConfiguration(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        map[interface{}]interface{}
+		wantType   ProxyType
+		wantAddr   string
+		wantSkip   bool
+		wantErr    bool
+	}{
+		{
+			name:     "http type",
+			cfg:      map[interface{}]interface{}{"type": "http", "address": "proxy:8080"},
+			wantType: ProxyTypeHttpConnect,
+			wantAddr: "proxy:8080",
+		},
+		{
+			name:     "https type",
+			cfg:      map[interface{}]interface{}{"type": "https", "address": "proxy:443"},
+			wantType: ProxyTypeHttpsConnect,
+			wantAddr: "proxy:443",
+		},
+		{
+			name:     "https with skipVerify true",
+			cfg:      map[interface{}]interface{}{"type": "https", "address": "proxy:443", "skipVerify": true},
+			wantType: ProxyTypeHttpsConnect,
+			wantAddr: "proxy:443",
+			wantSkip: true,
+		},
+		{
+			name:     "https skipVerify defaults false",
+			cfg:      map[interface{}]interface{}{"type": "https", "address": "proxy:443"},
+			wantType: ProxyTypeHttpsConnect,
+			wantAddr: "proxy:443",
+			wantSkip: false,
+		},
+		{
+			name:    "skipVerify invalid type",
+			cfg:     map[interface{}]interface{}{"type": "https", "address": "proxy:443", "skipVerify": "yes"},
+			wantErr: true,
+		},
+		{
+			name:    "https missing address",
+			cfg:     map[interface{}]interface{}{"type": "https"},
+			wantErr: true,
+		},
+		{
+			name:     "none type",
+			cfg:      map[interface{}]interface{}{"type": "none"},
+			wantType: ProxyTypeNone,
+		},
+		{
+			name:    "unknown type",
+			cfg:     map[interface{}]interface{}{"type": "socks5"},
+			wantErr: true,
+		},
+		{
+			name:    "missing type",
+			cfg:     map[interface{}]interface{}{"address": "proxy:8080"},
+			wantErr: true,
+		},
+		{
+			name:     "http with auth",
+			cfg:      map[interface{}]interface{}{"type": "http", "address": "proxy:8080", "username": "user", "password": "pass"},
+			wantType: ProxyTypeHttpConnect,
+			wantAddr: "proxy:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := LoadProxyConfiguration(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if result.Type != tt.wantType {
+				t.Errorf("type = %s, want %s", result.Type, tt.wantType)
+			}
+			if result.Address != tt.wantAddr {
+				t.Errorf("address = %s, want %s", result.Address, tt.wantAddr)
+			}
+			if result.SkipVerify != tt.wantSkip {
+				t.Errorf("skipVerify = %v, want %v", result.SkipVerify, tt.wantSkip)
+			}
+		})
+	}
+}
+
 func TestHostPortString(t *testing.T) {
 	tests := []struct {
 		name string

--- a/proxies/http_connect.go
+++ b/proxies/http_connect.go
@@ -19,6 +19,7 @@ package proxies
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
@@ -39,11 +40,24 @@ func NewHttpConnectProxyDialer(dialer proxy.Dialer, addr string, auth *proxy.Aut
 	}
 }
 
+func NewHttpsConnectProxyDialer(dialer proxy.Dialer, addr string, auth *proxy.Auth, timeout time.Duration, skipVerify bool) *HttpConnectProxyDialer {
+	return &HttpConnectProxyDialer{
+		dialer:     dialer,
+		address:    addr,
+		auth:       auth,
+		timeout:    timeout,
+		useTLS:     true,
+		skipVerify: skipVerify,
+	}
+}
+
 type HttpConnectProxyDialer struct {
-	dialer  proxy.Dialer
-	address string
-	auth    *proxy.Auth
-	timeout time.Duration
+	dialer     proxy.Dialer
+	address    string
+	auth       *proxy.Auth
+	timeout    time.Duration
+	useTLS     bool
+	skipVerify bool
 }
 
 func (self *HttpConnectProxyDialer) Dial(network, addr string) (net.Conn, error) {
@@ -54,6 +68,22 @@ func (self *HttpConnectProxyDialer) Dial(network, addr string) (net.Conn, error)
 	c, err := dialer.Dial(network, self.address)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to connect to proxy server at %s", self.address)
+	}
+
+	if self.useTLS {
+		host, _, splitErr := net.SplitHostPort(self.address)
+		if splitErr != nil {
+			host = self.address
+		}
+		tlsConn := tls.Client(c, &tls.Config{
+			ServerName:         host,
+			InsecureSkipVerify: self.skipVerify,
+		})
+		if err = tlsConn.Handshake(); err != nil {
+			_ = c.Close()
+			return nil, errors.Wrapf(err, "TLS handshake with proxy server at %s failed", self.address)
+		}
+		c = tlsConn
 	}
 
 	if err = self.Connect(c, addr); err != nil {

--- a/tls/dialer.go
+++ b/tls/dialer.go
@@ -50,18 +50,22 @@ func DialWithLocalBinding(a address, name, localBinding string, i *identity.Toke
 	var tlsConn *tls.Conn
 
 	if proxyConf != nil && proxyConf.Type != transport.ProxyTypeNone {
-		if proxyConf.Type == transport.ProxyTypeHttpConnect {
+		var proxyDialer *proxies.HttpConnectProxyDialer
+		switch proxyConf.Type {
+		case transport.ProxyTypeHttpConnect:
 			log.Infof("using http connect proxy at %s", proxyConf.Address)
-			proxyDialer := proxies.NewHttpConnectProxyDialer(dialer, proxyConf.Address, proxyConf.Auth, timeout)
-			conn, err := proxyDialer.Dial("tcp", destination)
-			if err != nil {
-				return nil, err
-			}
-
-			tlsConn = tls.Client(conn, tlsCfg)
-		} else {
+			proxyDialer = proxies.NewHttpConnectProxyDialer(dialer, proxyConf.Address, proxyConf.Auth, timeout)
+		case transport.ProxyTypeHttpsConnect:
+			log.Infof("using https connect proxy at %s", proxyConf.Address)
+			proxyDialer = proxies.NewHttpsConnectProxyDialer(dialer, proxyConf.Address, proxyConf.Auth, timeout, proxyConf.SkipVerify)
+		default:
 			return nil, errors.Errorf("unsupported proxy type %s", string(proxyConf.Type))
 		}
+		conn, err := proxyDialer.Dial("tcp", destination)
+		if err != nil {
+			return nil, err
+		}
+		tlsConn = tls.Client(conn, tlsCfg)
 	} else {
 		tlsConn, err = tls.DialWithDialer(dialer, "tcp", destination, tlsCfg)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Adds `type: https` proxy support so ziti-router can connect to HTTP CONNECT proxies over TLS
- Uses system CA certificates for proxy TLS verification (not Ziti identity certs)
- Adds optional `skipVerify` config field for environments with self-signed proxy certificates
- Fully backward compatible — existing `type: http` behavior is unchanged

## Motivation

Currently, ziti-router only supports plain TCP connections to HTTP CONNECT proxies (`type: http`). Users behind HTTPS proxies (where the proxy listener requires TLS) are not supported and must deploy external ad-hoc TLS-terminating sidecars like `stunnel` or `socat` as a patchy workaround.

This PR adds native TLS-to-proxy support, eliminating the need for that workaround.

## Connection flow

```
type: http   →  Router --[plain TCP]--> proxy:8080 --[CONNECT]--> destination (supported today)
type: https  →  Router --[TLS]-------> proxy:443  --[CONNECT over TLS]--> destination (added in this PR)
```

## Config examples

```yaml
# HTTPS proxy
proxy:
  type: https
  address: my-proxy:443

# HTTPS proxy with self-signed cert
proxy:
  type: https
  address: my-proxy:443
  skipVerify: true

# HTTPS proxy with auth
proxy:
  type: https
  address: my-proxy:443
  username: user
  password: pass
```

## Changes

| File | Change |
|------|--------|
| `address.go` | Add `ProxyTypeHttpsConnect` constant, `SkipVerify` field, config parsing |
| `proxies/http_connect.go` | Add `NewHttpsConnectProxyDialer` constructor, TLS wrapping in `Dial()` |
| `tls/dialer.go` | Handle new `https` proxy type in connection dispatch |
| `address_test.go` | 10 table-driven tests for proxy config parsing |

## Design decisions

- **System CA certs for proxy TLS** — `tls.Config{}` with no `RootCAs` uses the OS cert pool, keeping Ziti identity certs separate
- **Eager `Handshake()`** — TLS errors are caught immediately with clear messages before attempting CONNECT
- **`skipVerify` defaults to `false`** — secure by default, opt-in for corporate environments with internal CAs
